### PR TITLE
[Build] Update submodules only if not in node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "lint": "eslint .",
         "docs": "typedoc",
         "docs:watch": "typedoc --watch",
-        "preinstall": "git submodule init && git submodule update --checkout"
+        "preinstall": "bash ./scripts/prepare_submodules.sh"
     },
     "lint-staged": {
         "**/*": "prettier --write --ignore-unknown"

--- a/scripts/prepare_submodules.sh
+++ b/scripts/prepare_submodules.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Prevent sub module fetching in node_modules folder.
+# The relative gitdir in .git points to a non existing directory
+echo Preparing submodules...
+if [[ $(pwd) != *"node_modules"* ]]; then
+    git submodule update --init --checkout
+fi


### PR DESCRIPTION
## Update submodules only if not in node_modules
If we are building in camino-wallet, yarn / npm are triggering the preinstall hook after copying the code into node_modules.

A: it is not required to update submodules again, because it was done already in the initial preinstall step, and
B: it leads to a failure, because the relative gitdir path in .git file does not point to a valid git repo.

This PR only updates submodules if NOT in node_modules folder.