### PR TITLE
[BUILD] Change branch name dev_dist -> dist for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "caminojs"]
 	path = caminojs
 	url = https://github.com/chain4travel/caminojs.git
-	branch = dev-dist
+	branch = dist

--- a/scripts/prepare_submodules.sh
+++ b/scripts/prepare_submodules.sh
@@ -4,5 +4,5 @@
 # The relative gitdir in .git points to a non existing directory
 echo Preparing submodules...
 if [[ $(pwd) != *"node_modules"* ]]; then
-    git submodule update --init --checkout
+    git submodule update --init
 fi


### PR DESCRIPTION
## Change branch name dev_dist -> dist for submodules
From now on we use the same dist branch for chain4travel and dev, the commit hash decides about what version we use