### PR TITLE
Signavault address field in network configuration

### DIFF
--- a/src/Network/types.ts
+++ b/src/Network/types.ts
@@ -13,6 +13,7 @@ export interface NetworkConfig {
     apiPort: number;
     explorerURL?: string;
     explorerSiteURL?: string;
+    signavaultURL?: string;
     networkID: number;
     evmChainID: number;
     xChainID: string;

--- a/src/helpers/network_helper.ts
+++ b/src/helpers/network_helper.ts
@@ -48,6 +48,17 @@ export function createExplorerApi(networkConfig: NetworkConfig) {
 }
 
 /**
+ * Given a network configuration returns an HttpClient instance connected to the signavault
+ */
+export function createSignavaultApi(networkConfig: NetworkConfig) {
+    if (!networkConfig.signavaultURL) {
+        throw new Error('Network configuration does not specify an explorer API.');
+    }
+
+    return new HttpClient(networkConfig.signavaultURL);
+}
+
+/**
  * Checks if the given network accepts credentials.
  * This must be true to use cookies.
  */


### PR DESCRIPTION
This PR adds signavault address field for networks. This address will be used to interact with [Signavault](https://github.com/chain4travel/camino-signavault)